### PR TITLE
Bugfix: Notification sound plays when no new channels have gone live

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -402,9 +402,9 @@ exports.main = function(options, callbacks) {
             });
         }
 
-        // Play audio if OS is Windows
-        if (platform == 'winnt' && getStorageItem('notifySound') == true) {
-            panel.port.emit('playSound', getStorageItem('notifySoundRing'));
+        // Play audio if OS is Windows and we have actual channels gone live, if count < 1 this method causes no notification yet sound would still play
+        if (platform == 'winnt' && getStorageItem('notifySound') == true && count >= 1) {
+		panel.port.emit('playSound', getStorageItem('notifySoundRing'));
         }
 
         // If newlivefollowings is not empty, pass it's content to main array and empty it.


### PR DESCRIPTION
Code that plays the sound was independent of whether or not a notification was actually displayed. Quick fix for this. 
Thanks for the nice and simple addon @canaltinova !
